### PR TITLE
Delete unused data resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,30 +58,6 @@ resource "aws_cloudwatch_log_group" "sftp_log_group" {
 # Module      : IAM POLICY
 # Description : This data source can be used to fetch information about a specific IAM role.
 
-data "aws_iam_policy_document" "transfer_server_assume_role" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "transfer_server_assume_policy" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:*",
-    ]
-
-    resources = ["*"]
-  }
-}
-
 data "aws_iam_policy_document" "s3_access_for_sftp_users" {
   for_each = var.enabled ? local.user_names_map : {}
   statement {


### PR DESCRIPTION
## what
* Removed unused data `aws_iam_policy_document` resources. These resources are not referenced anywhere. I noticed that they were added 4 years ago, probably you forgot about them :)

## why
* Make code cleaner, there is no point in having these resources in the code. Also, it can confuse if someone checks IAM part of the module code.

## references
* No references
