### PR TITLE
Feat: Dynamically using retention policy for SFTP's log group.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ data "aws_s3_bucket" "landing" {
 
 resource "aws_cloudwatch_log_group" "sftp_log_group" {
   name              = "/aws/transfer/${module.labels.id}"
-  retention_in_days = 90
+  retention_in_days = var.retention_in_days
 }
 
 ##----------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -117,11 +117,16 @@ variable "subnet_ids" {
   default     = []
 }
 
-
 variable "security_policy_name" {
   type        = string
   description = "Specifies the name of the security policy that is attached to the server. Possible values are TransferSecurityPolicy-2018-11, TransferSecurityPolicy-2020-06, and TransferSecurityPolicy-FIPS-2020-06. Default value is: TransferSecurityPolicy-2018-11."
   default     = "TransferSecurityPolicy-2018-11"
+}
+
+variable "retention_in_days" {
+  type        = number
+  description = "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."
+  default     = 3
 }
 
 variable "domain_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,6 @@
 #Module      : LABEL
 #Description : Terraform label module variables.
 ##----------------------------------------------------------------------------------
-
 variable "name" {
   type        = string
   default     = ""
@@ -49,20 +48,17 @@ variable "enabled" {
 #Module      : SFTP
 #Description : Terraform sftp module variables.
 ##----------------------------------------------------------------------------------
-
 variable "enable_sftp" {
   type        = bool
   default     = true
   description = "Set to false to prevent the module from creating any resources."
 }
 
-
 variable "identity_provider_type" {
   type        = string
   default     = "SERVICE_MANAGED"
   description = "The mode of authentication enabled for this service. The default value is SERVICE_MANAGED, which allows you to store and access SFTP user credentials within the service. API_GATEWAY."
 }
-
 
 variable "s3_bucket_name" {
   type        = string


### PR DESCRIPTION
## what
* Using dynamic retention policy allocation for SFTP's Cloudwatch Log group.

## why
* Default value for 30 Das and static, having dependency of retention in i-sec so did dynamic changes.
