### PR TITLE
Fix sftp users ssh resource, add custom domain tag and more improvments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 resource "aws_iam_role" "s3_access_for_sftp_users" {
   for_each = var.enabled ? local.user_names_map : {}
 
-  name                = module.labels.id
+  name                = "${module.labels.id}-${each.value.user_name}"
   assume_role_policy  = join("", data.aws_iam_policy_document.assume_role_policy[*].json)
   managed_policy_arns = [aws_iam_policy.s3_access_for_sftp_users[each.value.user_name].arn]
 }
@@ -136,7 +136,7 @@ resource "aws_iam_role" "s3_access_for_sftp_users" {
 resource "aws_iam_policy" "s3_access_for_sftp_users" {
   for_each = var.enabled ? local.user_names_map : {}
 
-  name   = module.labels.id
+  name   = "${module.labels.id}-${each.value.user_name}"
   policy = data.aws_iam_policy_document.s3_access_for_sftp_users[each.value.user_name].json
 
   tags = module.labels.tags
@@ -149,7 +149,7 @@ resource "aws_iam_policy" "s3_access_for_sftp_users" {
 resource "aws_iam_policy" "logging" {
   count = var.enabled ? 1 : 0
 
-  name   = module.labels.id
+  name   = "${module.labels.id}-logging"
   policy = join("", data.aws_iam_policy_document.logging[*].json)
 
   tags = module.labels.tags
@@ -158,7 +158,7 @@ resource "aws_iam_policy" "logging" {
 resource "aws_iam_role" "logging" {
   count = var.enabled ? 1 : 0
 
-  name                = module.labels.id
+  name                = "${module.labels.id}-logging"
   assume_role_policy  = join("", data.aws_iam_policy_document.assume_role_policy[*].json)
   managed_policy_arns = [join("", aws_iam_policy.logging[*].arn)]
 
@@ -171,7 +171,7 @@ resource "aws_iam_role" "logging" {
 ##----------------------------------------------------------------------------------
 
 resource "aws_transfer_server" "transfer_server" {
-  count                  = var.enable_sftp ? 1 : 0
+  count                  = var.enabled ? 1 : 0
   identity_provider_type = var.identity_provider_type
   protocols              = ["SFTP"]
   domain                 = var.domain
@@ -240,10 +240,10 @@ resource "aws_transfer_user" "transfer_server_user" {
 ##----------------------------------------------------------------------------------
 
 resource "aws_transfer_ssh_key" "transfer_server_ssh_key" {
-  count     = var.enabled ? length(var.sftp_users) : 0
+  for_each = var.enabled ? { for user in var.sftp_users : user.user_name => user } : {}
   server_id = join("", aws_transfer_server.transfer_server[*].id)
-  user_name = aws_transfer_user.transfer_server_user[count.index].user_name
-  body      = aws_transfer_user.transfer_server_user[count.index].public_key
+  user_name = aws_transfer_user.transfer_server_user[each.value.user_name].user_name
+  body      = each.value.public_key
 }
 
 
@@ -263,10 +263,17 @@ resource "aws_eip" "sftp" {
 # Description : Provides a Custom Domain
 ##----------------------------------------------------------------------------------
 
-resource "aws_route53_record" "custom_domain" {
-  count = var.enabled && length(var.domain_name) > 0 && length(var.zone_id) > 0 ? 1 : 0
+resource "aws_transfer_tag" "custom_hostname" {
+  count        = var.enabled && length(var.custom_domain) > 0 ? 1 : 0
+  resource_arn = aws_transfer_server.transfer_server[0].arn
+  key          = "aws:transfer:customHostname"
+  value        = var.custom_domain
+}
 
-  name    = var.domain_name
+resource "aws_route53_record" "custom_domain" {
+  count = var.enabled && length(var.custom_domain) > 0 && length(var.zone_id) > 0 ? 1 : 0
+
+  name    = var.custom_domain
   zone_id = var.zone_id
   type    = "CNAME"
   ttl     = "300"

--- a/variables.tf
+++ b/variables.tf
@@ -48,11 +48,6 @@ variable "enabled" {
 #Module      : SFTP
 #Description : Terraform sftp module variables.
 ##----------------------------------------------------------------------------------
-variable "enable_sftp" {
-  type        = bool
-  default     = true
-  description = "Set to false to prevent the module from creating any resources."
-}
 
 variable "identity_provider_type" {
   type        = string
@@ -125,9 +120,9 @@ variable "retention_in_days" {
   default     = 3
 }
 
-variable "domain_name" {
+variable "custom_domain" {
   type        = string
-  description = "Domain to use when connecting to the SFTP endpoint"
+  description = "Custom domain to use when connecting to the SFTP endpoint"
   default     = ""
 }
 
@@ -151,6 +146,7 @@ variable "workflow_details" {
     })
   })
   description = "Workflow details for triggering the execution on file upload."
+  default = null
 }
 
 variable "enable_workflow" {


### PR DESCRIPTION
## what
- Fixed IAM policies and roles names to have user name because fixed names will prevent policy/role creation since it will be exist 
- Fixed users ssh resource to have for_each and point to the correct public key and user name
- Add setting custom domain for SFTP server using  transfer:customHostname tag
- deprecate var.enable_sftp in favour of var.enabled

## why

- General improvements and cleaner usage
